### PR TITLE
Dockerfile: Add missing copy for langgraph4j-agents

### DIFF
--- a/app/copilot/Dockerfile
+++ b/app/copilot/Dockerfile
@@ -10,6 +10,7 @@ COPY copilot-backend copilot-backend
 COPY copilot-common copilot-common
 COPY langchain4j-agents langchain4j-agents
 COPY langchain4j-openapi langchain4j-openapi
+COPY langgraph4j-agents langgraph4j-agents
 
 RUN chmod +x ./mvnw
 # Convert CRLF to LF


### PR DESCRIPTION
This pull request includes a small change to the `app/copilot/Dockerfile`. The change adds a new `COPY` command to include the `langgraph4j-agents` directory in the Docker image.

## ISSUE

While executing `azd up`, there was an error that the `langgraph4j-agents` directory was missing in the Docker image.

The root cause of this issue was that the `langgraph4j-agents` directory was not included in the Docker image.

```
> azd up 
 
 (✓) Done: Resource group: rg-javaonazure-demo-eastus2-001 (5.017s)

  (✓) Done: Log Analytics workspace: log-vcriaha33ayrs (18.314s)

  (✓) Done: Storage account: stvcriaha33ayrs (25.294s)

  (✓) Done: Document Intelligence: cog-fr-vcriaha33ayrs (37.8s)

  (✓) Done: Azure OpenAI: cog-vcriaha33ayrs (38.886s)

  (✓) Done: Application Insights: appi-vcriaha33ayrs (3.965s)

  (✓) Done: Azure AI Services Model Deployment: cog-vcriaha33ayrs/gpt-4o-mini (362ms)

  (✓) Done: Container Registry: crvcriaha33ayrs (23.584s)

  (✓) Done: Container Apps Environment: cae-vcriaha33ayrs (1m8.646s)

  (✓) Done: Container App: ca-transaction-vcriaha33ayrs (30.74s)

  (✓) Done: Container App: ca-account-vcriaha33ayrs (28.95s)

  (✓) Done: Container App: ca-payment-vcriaha33ayrs (25.032s)

  (✓) Done: Container App: ca-copilot-vcriaha33ayrs (27.42s)

  (✓) Done: Container App: ca-web-vcriaha33ayrs (31.783s)

Deploying services (azd deploy)
 
  (✓) Done: Deploying service account

  - Endpoint: https://ca-account-vcriaha33ayrs.internal.bluestone-f03769e0.eastus2.azurecontainerapps.io/
 
  (x) Failed: Deploying service copilot
 
ERROR: error executing step command 'deploy --all': failed deploying service 'copilot': remote build failed: 2025/05/19 13:36:45 Downloading source code...

2025/05/19 13:36:46 Finished downloading source code

2025/05/19 13:36:46 Using acb_vol_088f4b3a-0398-4a4a-902a-2dd6b50debe8 as the home volume

2025/05/19 13:36:46 Setting up Docker configuration...

2025/05/19 13:36:47 Successfully set up Docker configuration

2025/05/19 13:36:47 Logging in to registry: crvcriaha33ayrs.azurecr.io

2025/05/19 13:36:47 Successfully logged into crvcriaha33ayrs.azurecr.io

2025/05/19 13:36:47 Executing step ID: build. Timeout(sec): 28800, Working directory: '', Network: ''

2025/05/19 13:36:47 Scanning for dependencies...

2025/05/19 13:36:48 Successfully scanned dependencies

2025/05/19 13:36:48 Launching container with name: build

Sending build context to Docker daemon  390.1kB

Step 1/26 : FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu AS build

17-ubuntu: Pulling from openjdk/jdk

215ed5a63843: Pulling fs layer

ab6c4adfa733: Pulling fs layer

f7e58240930c: Pulling fs layer

f7e58240930c: Verifying Checksum

f7e58240930c: Download complete

215ed5a63843: Verifying Checksum

215ed5a63843: Download complete

ab6c4adfa733: Verifying Checksum

ab6c4adfa733: Download complete

215ed5a63843: Pull complete

ab6c4adfa733: Pull complete

f7e58240930c: Pull complete

Digest: sha256:544c7368b1d7c705fd4124864c3c477b5f4cd41e18f49b9fb71f3ce1a2277590

Status: Downloaded newer image for mcr.microsoft.com/openjdk/jdk:17-ubuntu

---> 68b8aa857a4f

Step 2/26 : WORKDIR /workspace/app

---> Running in 856726f039e6

Removing intermediate container 856726f039e6

---> 0264661e8781

Step 3/26 : EXPOSE 3100

---> Running in 4a09f8a04d41

Removing intermediate container 4a09f8a04d41

---> 14d984560645

Step 4/26 : COPY mvnw .

---> c0570101c0cc

Step 5/26 : COPY .mvn .mvn

---> d487a1ef18ae

Step 6/26 : COPY pom.xml .

---> 596a8e804e69

Step 7/26 : COPY copilot-backend copilot-backend

---> 22129500f1f7

Step 8/26 : COPY copilot-common copilot-common

---> 7e18e727f1fa

Step 9/26 : COPY langchain4j-agents langchain4j-agents

---> c4d65d3b511e

Step 10/26 : COPY langchain4j-openapi langchain4j-openapi

---> 899c64136692

Step 11/26 : RUN chmod +x ./mvnw

---> Running in c6624470ceab

Removing intermediate container c6624470ceab

---> 902e0782e518

Step 12/26 : RUN sed -i 's/\r$//' ./mvnw

---> Running in 79cd90d84e69

Removing intermediate container 79cd90d84e69

---> 257d6e02be58

Step 13/26 : RUN ./mvnw package -DskipTests

---> Running in e1561f2f65c1

[INFO] Scanning for projects...

Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/3.3.6/spring-boot-starter-parent-3.3.6.pom

Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/3.3.6/spring-boot-starter-parent-3.3.6.pom (13 kB at 43 kB/s)

Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/3.3.6/spring-boot-dependencies-3.3.6.pom

Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/3.3.6/spring-boot-dependencies-3.3.6.pom (100 kB at 1.9 MB/s)

Downloading from central: https://repo.maven.apache.org/maven2/com/azure/azure-sdk-bom/1.2.33/azure-sdk-bom-1.2.33.pom

Downloaded from central: https://repo.maven.apache.org/maven2/com/azure/azure-sdk-bom/1.2.33/azure-sdk-bom-1.2.33.pom (16 kB at 729 kB/s)

[ERROR] [ERROR] Some problems were encountered while processing the POMs:

[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 35, column 21

[ERROR] Child module /workspace/app/langgraph4j-agents of /workspace/app/pom.xml does not exist @

@

[ERROR] The build could not read 1 project -> [Help 1]

[ERROR]

[ERROR]   The project com.microsoft.openai.samples.assistant:copilot-parent:1.0.0-SNAPSHOT (/workspace/app/pom.xml) has 1 error

[ERROR]     Child module /workspace/app/langgraph4j-agents of /workspace/app/pom.xml does not exist

[ERROR]

[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.

[ERROR] Re-run Maven using the -X switch to enable full debug logging.

[ERROR]

[ERROR] For more information about the errors and possible solutions, please read the following articles:

[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException

The command '/bin/sh -c ./mvnw package -DskipTests' returned a non-zero code: 1

2025/05/19 13:37:09 Container failed during run: build. No retries remaining.

failed to run step ID: build: exit status 1
 
Run ID: ch2 failed after 24s. Error: failed during run, err: exit status 1
 
WARNING: your version of azd is out of date, you have 1.15.1 and the latest version is 1.16.1
 
To update to the latest version, run:

winget upgrade Microsoft.Azd
```